### PR TITLE
readfq2.py is ~60% faster readfq.py

### DIFF
--- a/readfq2.py
+++ b/readfq2.py
@@ -2,7 +2,6 @@
 
 import sys
 import itertools
-import numba
 
 def readfq(fp): # this is a generator function
 

--- a/readfq2.py
+++ b/readfq2.py
@@ -1,82 +1,23 @@
 #!/usr/bin/env python
 
-BUFFER_SIZE = 1024 * 1024;
+import sys
+import itertools
+import numba
 
 def readfq(fp): # this is a generator function
 
-    rest = []
-
-    newline = False
-    
-    a = fp.read(1)
-    if a == "@":
-        # FASTQ
-        rest = [a]
-        while True:
-            buffer = fp.read(BUFFER_SIZE)
-            if not buffer:
-                if rest and len(rest) == 4:
-                    yield(rest[0],rest[1],rest[3])
-                break
-            if rest:
-                if newline:
-                    lines = "".join(("\n".join(rest),'\n', buffer)).splitlines()
-                else:
-                    lines = "".join(("\n".join(rest), buffer)).splitlines()
-            else:
-                lines = buffer.splitlines()
-            newline = True if buffer[-1] == '\n' else False
-            n = len(lines)
-            m = 4 * int((n-1)/4)
-            r = n - m
-            if newline and r == 4:
-                rest = []
-                m = m + 1
-            else:
-                rest = lines[m:n]
-            for i in range(0,m,4):
-                yield (lines[i], lines[i+1], lines[i+3])
-                
-    elif a == ">":
-        # FASTA
-        rest = a
-        while True:
-            buffer = fp.read(BUFFER_SIZE)
-            if not buffer:
-                if rest:
-                    u = rest.partition("\n")
-                    yield (u[0],u[2].rstrip("\n"),"")
-                break
-            if rest:
-                lines = "".join((rest,buffer)).splitlines()
-            else:
-                lines = buffer.splitlines()
-
-            n = len(lines)
-            x = [i for i,e in enumerate(map(lambda u: u[0] if u else '',lines)) if e==">"]
-
-            newline = True if buffer[-1] == '\n' else False
-            b = x[-1]
-            if b==n-1:
-                if newline:
-                    rest = "\n".join((lines[b],"\n"))
-                else:
-                    rest = lines[b]
-            elif newline:
-                rest = "".join((lines[b],"\n","".join(lines[b+1:n]),"\n"))
-            else:
-                rest = "".join((lines[b],"\n","".join(lines[b+1:n])))
-            for i in range(1,len(x)):
-                b = x[i-1]
-                c = x[i]
-                yield (lines[b],"".join(lines[b+1:c]),'')
+    rstrip = str.rstrip
+    for aread in itertools.izip_longest(*[fp]*4):
+        yield (rstrip(aread[0]),rstrip(aread[1]),rstrip(aread[3]))
 
 
 if __name__ == "__main__":
-    import sys
     n, slen, qlen = 0, 0, 0
-    for name, seq, qual in readfq(sys.stdin):
+
+    for aread in readfq(sys.stdin):
         n += 1
-        slen += len(seq)
-        qlen += qual and len(qual) or 0
+        slen += len(aread[1])
+        qlen += len(aread[2])
     print n, '\t', slen, '\t', qlen
+
+

--- a/readfq2.py
+++ b/readfq2.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+
+
+BUFFER_SIZE = 1024 * 1024;
+
+def readfq(fp): # this is a generator function
+    rest = []
+    newline = False
+    while True:
+        buffer = fp.read(BUFFER_SIZE)
+        if not buffer:
+            break
+        lines = buffer.splitlines()
+        if rest:
+            if not newline:
+                v = rest.pop(-1)
+                lines[0] = "%s%s" % (v,lines[0])
+            rest.extend(lines)
+            lines = rest
+        newline = True if buffer[-1] == '\n' else False
+        n = len(lines)
+        m = 4 * int((n-1)/4)
+        r = n - m
+        #if r != 4 or not newline:
+        #    rest = lines[m:n]
+        if newline and r == 4:
+            rest = []
+            m = m + 1
+        else:
+            rest = lines[m:n]
+        for i in range(0,m,4):
+            yield (lines[i], lines[i+1], lines[i+3])
+
+if __name__ == "__main__":
+    import sys
+    n, slen, qlen = 0, 0, 0
+    for name, seq, qual in readfq(sys.stdin):
+        n += 1
+        slen += len(seq)
+        qlen += qual and len(qual) or 0
+    print n, '\t', slen, '\t', qlen

--- a/readfq2.py
+++ b/readfq2.py
@@ -3,30 +3,74 @@
 BUFFER_SIZE = 1024 * 1024;
 
 def readfq(fp): # this is a generator function
+
     rest = []
+
     newline = False
-    while True:
-        buffer = fp.read(BUFFER_SIZE)
-        if not buffer:
-            break
-        lines = buffer.splitlines()
-        if rest:
-            if not newline:
-                v = rest.pop(-1)
-                lines[0] = "%s%s" % (v,lines[0])
-            rest.extend(lines)
-            lines = rest
-        newline = True if buffer[-1] == '\n' else False
-        n = len(lines)
-        m = 4 * int((n-1)/4)
-        r = n - m
-        if newline and r == 4:
-            rest = []
-            m = m + 1
-        else:
-            rest = lines[m:n]
-        for i in range(0,m,4):
-            yield (lines[i], lines[i+1], lines[i+3])
+    
+    a = fp.read(1)
+    if a == "@":
+        # FASTQ
+        rest = [a]
+        while True:
+            buffer = fp.read(BUFFER_SIZE)
+            if not buffer:
+                if rest and len(rest) == 4:
+                    yield(rest[0],rest[1],rest[3])
+                break
+            if rest:
+                if newline:
+                    lines = "".join(("\n".join(rest),'\n', buffer)).splitlines()
+                else:
+                    lines = "".join(("\n".join(rest), buffer)).splitlines()
+            else:
+                lines = buffer.splitlines()
+            newline = True if buffer[-1] == '\n' else False
+            n = len(lines)
+            m = 4 * int((n-1)/4)
+            r = n - m
+            if newline and r == 4:
+                rest = []
+                m = m + 1
+            else:
+                rest = lines[m:n]
+            for i in range(0,m,4):
+                yield (lines[i], lines[i+1], lines[i+3])
+                
+    elif a == ">":
+        # FASTA
+        rest = a
+        while True:
+            buffer = fp.read(BUFFER_SIZE)
+            if not buffer:
+                if rest:
+                    u = rest.partition("\n")
+                    yield (u[0],u[2].rstrip("\n"),"")
+                break
+            if rest:
+                lines = "".join((rest,buffer)).splitlines()
+            else:
+                lines = buffer.splitlines()
+
+            n = len(lines)
+            x = [i for i,e in enumerate(map(lambda u: u[0] if u else '',lines)) if e==">"]
+
+            newline = True if buffer[-1] == '\n' else False
+            b = x[-1]
+            if b==n-1:
+                if newline:
+                    rest = "\n".join((lines[b],"\n"))
+                else:
+                    rest = lines[b]
+            elif newline:
+                rest = "".join((lines[b],"\n","".join(lines[b+1:n]),"\n"))
+            else:
+                rest = "".join((lines[b],"\n","".join(lines[b+1:n])))
+            for i in range(1,len(x)):
+                b = x[i-1]
+                c = x[i]
+                yield (lines[b],"".join(lines[b+1:c]),'')
+
 
 if __name__ == "__main__":
     import sys

--- a/readfq2.py
+++ b/readfq2.py
@@ -20,8 +20,6 @@ def readfq(fp): # this is a generator function
         n = len(lines)
         m = 4 * int((n-1)/4)
         r = n - m
-        #if r != 4 or not newline:
-        #    rest = lines[m:n]
         if newline and r == 4:
             rest = []
             m = m + 1

--- a/readfq2.py
+++ b/readfq2.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-
-
 BUFFER_SIZE = 1024 * 1024;
 
 def readfq(fp): # this is a generator function


### PR DESCRIPTION
Using splitlines instead of [:-1] for removing \n at the end of the lines.
Using range(0,n,4) instead of looping for each line.
This is strictly only a FASTQ reader. 